### PR TITLE
Add turris-bci to RDK_MACHINE

### DIFF
--- a/build/vendor-arch.mk
+++ b/build/vendor-arch.mk
@@ -29,8 +29,8 @@ VERSION_NO_BUILDNUM = 1
 VERSION_NO_SHA1 = 1
 VERSION_NO_PROFILE = 1
 
-#This vendor layer support Turris Omnia as a residential gateway and Turris omnia as Extender/GW
-ifeq ($(RDK_MACHINE),$(filter $(RDK_MACHINE),turris turris-extender))
+#This vendor layer support Turris Omnia as a residential / business gateway and Turris omnia as Extender/GW
+ifeq ($(RDK_MACHINE),$(filter $(RDK_MACHINE),turris turris-extender turris-bci))
 
 RDK_OEM = turris
 RDK_MODEL = omnia


### PR DESCRIPTION
This allows Turris Omnia as a business gateway to build with opensync.