### PR TITLE
Include RDK_MACHINE as turris_5.10 for vendor component

### DIFF
--- a/build/vendor-arch.mk
+++ b/build/vendor-arch.mk
@@ -28,7 +28,7 @@ VERSION_NO_SHA1 = 1
 VERSION_NO_PROFILE = 1
 
 #This vendor layer support Turris Omnia as a residential / business gateway and Turris omnia as Extender/GW
-ifeq ($(RDK_MACHINE),$(filter $(RDK_MACHINE),turris turris-extender turris-bci))
+ifeq ($(RDK_MACHINE),$(filter $(RDK_MACHINE),turris turris-extender turris-bci turris_5.10))
 
 RDK_OEM = turris
 RDK_MODEL = omnia


### PR DESCRIPTION
REFPLTB-1363: Include RDK_MACHINE as turris_5.10 for vendor component

Reason for change: Building linux kernel5.10 version for Turris-Omnia
Test Procedure: Build and test
Risk: None

Signed-off-by: kaviya.kumaresan <kaviya.kumaresan@ltts.com>